### PR TITLE
rename-build

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -14,8 +14,8 @@ on:
       - 'v*'
 
 env:
-  APP_NAME: nubeio-rubix-app-bbb-rest-py
-  GHCR_IMAGE: ghcr.io/nubeio/nubeio-rubix-app-bbb-rest-py
+  APP_NAME: nubeio-rubix-app-bbb-py-rest
+  GHCR_IMAGE: ghcr.io/nubeio/nubeio-rubix-app-bbb-py-rest
   PLATFORMS: linux/amd64,linux/arm/v7
 
 jobs:


### PR DESCRIPTION
the build name dosnt match the repo name so its hard to do a download of the asset by string matching the repo name to the asset name